### PR TITLE
Add parseImageSize in comic-parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-* None
+### Added
+
+* Add `ComicParser.parseOptions.parseImageSize` option.
+* Add `ComicBook.Item.width` and `ComicBook.Item.height`.
+
+### Changed
+
+* Rename `ComicBook.Item.size` to `ComicBook.Item.fileSize`.
 
 ## [0.3.1 (2019-01-31)]
 

--- a/packages/comic-parser/README.md
+++ b/packages/comic-parser/README.md
@@ -181,7 +181,7 @@ parser.onProgress = (step, totalStep, action) => {
 
 - index: *?string*
 - path: *?string*
-- size: *?number*
+- fileSize: *?number*
 
 <a id="parseOptions"></a>
 

--- a/packages/comic-parser/README.md
+++ b/packages/comic-parser/README.md
@@ -182,6 +182,8 @@ parser.onProgress = (step, totalStep, action) => {
 - index: *?string*
 - path: *?string*
 - fileSize: *?number*
+- width: *?number*
+- height: *?number*
 
 <a id="parseOptions"></a>
 
@@ -190,6 +192,7 @@ parser.onProgress = (step, totalStep, action) => {
 * [unzipPath](#unzipPath)
 * [overwrite](#overwrite)
 * [ext](#ext)
+* [parseImageSize](#parseImageSize)
 
 ---
 
@@ -222,6 +225,16 @@ If true, overwrite to [unzipPath](#unzipPath) when unzip.
 File extension to allow when extracting lists.
 
 **Default:** `['jpg', 'jpeg', 'png', 'bmp', 'gif']`
+
+---
+
+<a id="parseImageSize"></a>
+
+### parseImageSize: *`boolean|number`*
+
+If true, image size parse. (parse may be slower.)
+
+**Default:** `false`
 
 <a id="readOptions"></a>
 

--- a/packages/comic-parser/package.json
+++ b/packages/comic-parser/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@ridi/parser-core": "^0.3.1",
     "fs-extra": "^7.0.1",
+    "image-size": "^0.7.1",
     "natural-orderby": "1.1.1"
   }
 }

--- a/packages/comic-parser/package.json
+++ b/packages/comic-parser/package.json
@@ -14,7 +14,9 @@
   "bugs": "https://github.com/ridi/content-parser/issues",
   "homepage": "https://github.com/ridi/content-parser",
   "files": [
-    "lib"
+    "lib",
+    "../../CHANGELOG.md",
+    "../../LICENSE"
   ],
   "main": "lib/index.js",
   "dependencies": {

--- a/packages/comic-parser/src/ComicParser.js
+++ b/packages/comic-parser/src/ComicParser.js
@@ -120,12 +120,12 @@ class ComicParser extends Parser {
         return ext.length > 0 && stringContains(options.ext.map(e => `.${e}`), ext);
       });
     rawBook.items = [];
-    await items.reduce((prevPromise, entry, index) => {
+    await items.reduce((prevPromise, item, index) => {
       return prevPromise.then(async () => {
         rawBook.items.push({
           index,
-          path: entry.entryPath,
-          size: entry.size,
+          path: item.entryPath,
+          fileSize: item.size,
         });
       });
     }, Promise.resolve());

--- a/packages/comic-parser/src/ComicParser.js
+++ b/packages/comic-parser/src/ComicParser.js
@@ -5,6 +5,7 @@ import {
   stringContains,
 } from '@ridi/parser-core';
 
+import sizeOf from 'image-size';
 import { orderBy } from 'natural-orderby';
 import path from 'path';
 
@@ -22,6 +23,8 @@ class ComicParser extends Parser {
       ...super.parseDefaultOptions,
       // File extension to allow when extracting lists.
       ext: ['jpg', 'jpeg', 'png', 'bmp', 'gif'],
+      // If true, image size parse. (parse may be slower.)
+      parseImageSize: false,
     };
   }
 
@@ -32,6 +35,7 @@ class ComicParser extends Parser {
     return {
       ...super.parseOptionTypes,
       ext: 'Array',
+      parseImageSize: 'Boolean|Number',
     };
   }
 
@@ -110,7 +114,8 @@ class ComicParser extends Parser {
    * extracts only necessary metadata from entries and create item list
    * @param {ReadContext} context intermediate result
    * @returns {Promise.<ReadContext>} return Context containing item list
-   * @see ComicParser.parseDefaultOptions.filter
+   * @see ComicParser.parseDefaultOptions.ext
+   * @see ComicParser.parseDefaultOptions.parseImageSize
    */
   async _parse(context) {
     const { entries, rawBook, options } = context;
@@ -126,10 +131,33 @@ class ComicParser extends Parser {
           index,
           path: item.entryPath,
           fileSize: item.size,
+          ...await this._parseImageSize(item, options),
         });
       });
     }, Promise.resolve());
     return context;
+  }
+
+  /**
+   * parse image size from entry
+   * @param {object} entry image entry
+   * @param {object} options parse options
+   * @returns {Promise.<object>} return image size
+   */
+  async _parseImageSize(entry, options) {
+    const { parseImageSize } = options;
+    if (parseImageSize === false) {
+      return {};
+    }
+    const readOptions = Number.isInteger(parseImageSize) ? { end: parseImageSize } : {};
+    const buffer = await entry.getFile(readOptions);
+    try {
+      const size = sizeOf(buffer);
+      return { width: size.width, height: size.height };
+    } catch (e) {
+      this.logger.error(e);
+      return { width: undefined, height: undefined };
+    }
   }
 
   /**

--- a/packages/comic-parser/src/model/Item.js
+++ b/packages/comic-parser/src/model/Item.js
@@ -1,3 +1,4 @@
+import { isExists } from '@ridi/parser-core';
 import path from 'path';
 
 class Item {
@@ -19,6 +20,12 @@ class Item {
     this.index = rawObj.index;
     this.path = rawObj.path;
     this.fileSize = rawObj.fileSize;
+    if (isExists(rawObj.width)) {
+      this.width = rawObj.width;
+    }
+    if (isExists(rawObj.height)) {
+      this.height = rawObj.height;
+    }
     /* istanbul ignore else */
     if (freeze && this.constructor === Item) {
       Object.freeze(this);
@@ -30,6 +37,8 @@ class Item {
       index: this.index,
       path: this.path,
       fileSize: this.fileSize,
+      ...(isExists(this.width) ? { width: this.width } : {}),
+      ...(isExists(this.height) ? { height: this.height } : {}),
     };
   }
 }

--- a/packages/comic-parser/src/model/Item.js
+++ b/packages/comic-parser/src/model/Item.js
@@ -18,7 +18,7 @@ class Item {
   constructor(rawObj = {}, freeze = true) {
     this.index = rawObj.index;
     this.path = rawObj.path;
-    this.size = rawObj.size;
+    this.fileSize = rawObj.fileSize;
     /* istanbul ignore else */
     if (freeze && this.constructor === Item) {
       Object.freeze(this);
@@ -29,7 +29,7 @@ class Item {
     return {
       index: this.index,
       path: this.path,
-      size: this.size,
+      fileSize: this.fileSize,
     };
   }
 }

--- a/packages/comic-parser/test/ComicParser.spec.js
+++ b/packages/comic-parser/test/ComicParser.spec.js
@@ -38,7 +38,7 @@ describe('ComicParser', () => {
           items.forEach((item) => {
             item.index.should.not.null;
             item.path.should.not.null;
-            item.size.should.not.null;
+            item.fileSize.should.not.null;
           });
           _context = context;
         });

--- a/packages/comic-parser/test/ComicParser.spec.js
+++ b/packages/comic-parser/test/ComicParser.spec.js
@@ -39,6 +39,8 @@ describe('ComicParser', () => {
             item.index.should.not.null;
             item.path.should.not.null;
             item.fileSize.should.not.null;
+            isExists(item.width).should.be.false;
+            isExists(item.height).should.be.false;
           });
           _context = context;
         });
@@ -72,6 +74,20 @@ describe('ComicParser', () => {
     it('Use ext option', () => {
       return new ComicParser(Paths.UNZIPPED_COMIC).parse({ ext: [] }).then(book => {
         book.items.length.should.equal(0);
+      });
+    });
+
+    it('Use parseImageSize option (boolean)', () => {
+      const parseOptions = { parseImageSize: true };
+      return new ComicParser(Paths.UNZIPPED_COMIC).parse(parseOptions).then(book => {
+        validationBook(book, JSON.parse(fs.readFileSync(Paths.EXPECTED_COMIC_BOOK_WITH_SIZE)), parseOptions);
+      });
+    });
+
+    it('Use parseImageSize option (number)', () => {
+      const parseOptions = { parseImageSize: 1024 * 50 };
+      return new ComicParser(Paths.UNZIPPED_COMIC).parse(parseOptions).then(book => {
+        validationBook(book, JSON.parse(fs.readFileSync(Paths.EXPECTED_COMIC_BOOK_WITH_SIZE)), parseOptions);
       });
     });
   });

--- a/packages/comic-parser/test/model/Item.spec.js
+++ b/packages/comic-parser/test/model/Item.spec.js
@@ -9,19 +9,19 @@ describe('Model - Item', () => {
     let item = new Item();
     assert(item.index === undefined);
     assert(item.path === undefined);
-    assert(item.size === undefined);
+    assert(item.fileSize === undefined);
 
     item = new Item({
-      index: 0, path: '0.png', size: 12345
+      index: 0, path: '0.png', fileSize: 12345
     });
     item.index.should.equal(0);
     item.path.should.equal('0.png');
-    item.size.should.equal(12345);
+    item.fileSize.should.equal(12345);
 
     (() => {
       item.index = 1;
       item.path = '1.png';
-      item.size = 54321;
+      item.fileSize = 54321;
     }).should.throw(/read only property/gi);
   });
 
@@ -32,13 +32,13 @@ describe('Model - Item', () => {
 
   it('toRaw test', () => {
     let item = new Item({});
-    item.toRaw().should.deep.equal({ index: undefined, path: undefined, size: undefined });
+    item.toRaw().should.deep.equal({ index: undefined, path: undefined, fileSize: undefined });
 
     item = new Item({
-      index: 0, path: '0.png', size: 12345
+      index: 0, path: '0.png', fileSize: 12345
     });
     item.toRaw().should.deep.equal({
-      index: 0, path: '0.png', size: 12345
+      index: 0, path: '0.png', fileSize: 12345
     });
   });
 });

--- a/packages/comic-parser/test/model/Item.spec.js
+++ b/packages/comic-parser/test/model/Item.spec.js
@@ -10,18 +10,24 @@ describe('Model - Item', () => {
     assert(item.index === undefined);
     assert(item.path === undefined);
     assert(item.fileSize === undefined);
+    assert(item.width === undefined);
+    assert(item.height === undefined);
 
     item = new Item({
-      index: 0, path: '0.png', fileSize: 12345
+      index: 0, path: '0.png', fileSize: 12345, width: 20, height: 20
     });
     item.index.should.equal(0);
     item.path.should.equal('0.png');
     item.fileSize.should.equal(12345);
+    item.width.should.equal(20);
+    item.height.should.equal(20);
 
     (() => {
       item.index = 1;
       item.path = '1.png';
       item.fileSize = 54321;
+      item.width = 10;
+      item.height = 10;
     }).should.throw(/read only property/gi);
   });
 
@@ -35,10 +41,10 @@ describe('Model - Item', () => {
     item.toRaw().should.deep.equal({ index: undefined, path: undefined, fileSize: undefined });
 
     item = new Item({
-      index: 0, path: '0.png', fileSize: 12345
+      index: 0, path: '0.png', fileSize: 12345, width: 20, height: 20
     });
     item.toRaw().should.deep.equal({
-      index: 0, path: '0.png', fileSize: 12345
+      index: 0, path: '0.png', fileSize: 12345, width: 20, height: 20
     });
   });
 });

--- a/packages/comic-parser/test/validationBook.js
+++ b/packages/comic-parser/test/validationBook.js
@@ -11,6 +11,6 @@ export default function validationBook(book, expectedBook) {
     const expectedItem = expectedBook.items[idx];
     item.index.should.equal(expectedItem.index);
     item.path.should.equal(expectedItem.path);
-    item.size.should.equal(expectedItem.size);
+    item.fileSize.should.equal(expectedItem.fileSize);
   });
 }

--- a/packages/comic-parser/test/validationBook.js
+++ b/packages/comic-parser/test/validationBook.js
@@ -3,14 +3,22 @@ import { isExists } from '@ridi/parser-core';
 import Book from '../src/model/Book';
 import Item from '../src/model/Item';
 
-export default function validationBook(book, expectedBook) {
+export default function validationBook(book, expectedBook, parseOptions = {}) {
   book.should.be.an.instanceOf(Book);
 
   book.items.should.have.lengthOf(expectedBook.items.length);
   book.items.forEach((item, idx) => {
     const expectedItem = expectedBook.items[idx];
+    const { parseImageSize } = parseOptions;
     item.index.should.equal(expectedItem.index);
     item.path.should.equal(expectedItem.path);
     item.fileSize.should.equal(expectedItem.fileSize);
+    if (parseImageSize === true || Number.isInteger(parseImageSize)) {
+      item.width.should.equal(expectedItem.width);
+      item.height.should.equal(expectedItem.height);
+    } else {
+      isExists(item.width).should.be.false;
+      isExists(item.height).should.be.false;
+    }
   });
 }

--- a/packages/comic-parser/yarn.lock
+++ b/packages/comic-parser/yarn.lock
@@ -14,6 +14,10 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.15"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
 
+image-size@^0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.7.1.tgz#961f7dfb1fc6bc7b8cb25e3986e1dc206b195eab"
+
 jsonfile@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"

--- a/packages/content-parser/package.json
+++ b/packages/content-parser/package.json
@@ -14,7 +14,9 @@
   "bugs": "https://github.com/ridi/content-parser/issues",
   "homepage": "https://github.com/ridi/content-parser",
   "files": [
-    "lib"
+    "lib",
+    "../../CHANGELOG.md",
+    "../../LICENSE"
   ],
   "main": "lib/index.js",
   "dependencies": {

--- a/packages/epub-parser/README.md
+++ b/packages/epub-parser/README.md
@@ -354,6 +354,9 @@ TEXT | text
 - index: *number* (**Default: undefined**)
 - isLinear: *boolean* (**Default: true**)
 - styles: *?[CssItem](#cssItem)[]*
+- first: *?[SpineItem](#spineItem)*
+- prev: *?[SpineItem](#spineItem)*
+- next: *?[SpineItem](#spineItem)*
 
 <a id="ncxItem"></a>
 

--- a/packages/epub-parser/package.json
+++ b/packages/epub-parser/package.json
@@ -24,7 +24,9 @@
     "crypto"
   ],
   "files": [
-    "lib"
+    "lib",
+    "../../CHANGELOG.md",
+    "../../LICENSE"
   ],
   "main": "lib/index.js",
   "dependencies": {

--- a/packages/epub-parser/src/EpubParser.js
+++ b/packages/epub-parser/src/EpubParser.js
@@ -180,7 +180,7 @@ class EpubParser extends Parser {
     const { entries, options } = context;
     if (!isString(entries.source) && options.validatePackage) {
       const firstEntry = context.entries.first;
-      const signature = await firstEntry.getFile('utf8');
+      const signature = await firstEntry.getFile({ encoding: 'utf8' });
       if (firstEntry.entryPath !== 'mimetype') {
         throw createError(Errors.EINVAL, 'package', 'reason', 'mimetype file must be first file in archive.');
       } else if (firstEntry.method !== 0 /* STORED */) {
@@ -220,7 +220,7 @@ class EpubParser extends Parser {
     //     ...                  ^~~~~~~~~~~~~~~~~
     //   </rootfiles>
     // </container>
-    const { container } = xmlLoader(await containerEntry.getFile('utf8'));
+    const { container } = xmlLoader(await containerEntry.getFile({ encoding: 'utf8' }));
     if (!isExists(container)) {
       throw createError(Errors.ENOELMT, 'container', entryPath);
     }
@@ -276,7 +276,7 @@ class EpubParser extends Parser {
     //   <guide>...</guide>
     //    ^~~~~~~~~~~~~~~~
     // </package>
-    const { package: root } = xmlLoader(await opfEntry.getFile('utf8'));
+    const { package: root } = xmlLoader(await opfEntry.getFile({ encoding: 'utf8' }));
     if (!isExists(root)) {
       throw createError(Errors.ENOELMT, 'package', opfPath);
     }
@@ -444,7 +444,7 @@ class EpubParser extends Parser {
     const find = (list, property, value) => list.find(item => item[property] === value);
     const filter = (list, property, value) => list.filter(item => item[property] === value);
 
-    const document = parseHtml(await entry.getFile('utf8'));
+    const document = parseHtml(await entry.getFile({ encoding: 'utf8' }));
     const html = find(document, 'tagName', 'html');
     if (!isExists(html)) {
       this.logger.error(`Can not analyze style in '${rawItem.href}'. (reason: no html tag)`);
@@ -564,7 +564,7 @@ class EpubParser extends Parser {
       //   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       //   ...
       // </ncx>
-      const { ncx } = xmlLoader(await ncxEntry.getFile('utf8'));
+      const { ncx } = xmlLoader(await ncxEntry.getFile({ encoding: 'utf8' }));
       if (!isExists(ncx)) {
         throw createError(Errors.ENOELMT, 'ncx', ncxItem.href);
       }
@@ -640,7 +640,7 @@ class EpubParser extends Parser {
           throw createError(Errors.ENOFILE, item.href);
         }
 
-        const file = await entry.getFile(item.defaultEncoding);
+        const file = await entry.getFile({ encoding: item.defaultEncoding });
         if (item instanceof SpineItem) {
           results.push(spineLoader(item, file, options));
         } else if (item instanceof CssItem) {

--- a/packages/parser-core/package.json
+++ b/packages/parser-core/package.json
@@ -14,7 +14,9 @@
   "bugs": "https://github.com/ridi/content-parser/issues",
   "homepage": "https://github.com/ridi/content-parser",
   "files": [
-    "lib"
+    "lib",
+    "../../CHANGELOG.md",
+    "../../LICENSE"
   ],
   "main": "lib/index.js",
   "dependencies": {

--- a/packages/parser-core/src/createRangeStream.js
+++ b/packages/parser-core/src/createRangeStream.js
@@ -1,0 +1,24 @@
+import es from 'event-stream';
+
+const createRangeStream = (start = 0, end = Infinity) => {
+  let bytesReceived = 0;
+  let finish = false;
+  return es.map((chunk, callback) => { // eslint-disable-line
+    bytesReceived += chunk.length;
+    if (!finish && bytesReceived >= start) {
+      if (start - (bytesReceived - chunk.length) > 0) {
+        chunk = chunk.slice(start - (bytesReceived - chunk.length));
+      }
+      if (end <= bytesReceived) {
+        callback(null, chunk.slice(0, chunk.length - (bytesReceived - end)));
+        finish = true;
+      } else {
+        callback(null, chunk);
+      }
+    } else {
+      callback();
+    }
+  });
+};
+
+export default createRangeStream;

--- a/packages/parser-core/src/readEntries.js
+++ b/packages/parser-core/src/readEntries.js
@@ -3,6 +3,7 @@ import path from 'path';
 
 import { removeAllCacheFiles, readCacheFile, writeCacheFile } from './cacheFile';
 import createCryptoStream from './createCryptoStream';
+import createRangeStream from './createRangeStream';
 import CryptoProvider from './CryptoProvider';
 import { getPathes, safePath } from './pathUtil';
 import { isExists } from './typecheck';
@@ -53,17 +54,17 @@ function fromDirectory(dir, cryptoProvider, resetCache) {
     return entries.concat([{
       entryPath: safePath(fullPath).substring(subPathOffset),
       getFile: async (options = {}) => {
+        const { encoding, end } = options;
         let file = await new Promise((resolve, reject) => {
-          const end = isExists(options.end) ? Math.max(options.end, size) : Infinity;
-          const stream = fs.createReadStream(fullPath, { encoding: 'binary', start: 0, end });
+          const stream = fs.createReadStream(fullPath, { encoding: 'binary' });
           let data = Buffer.from([]);
           stream
+            .pipe(createRangeStream(0, end))
             .pipe(createCryptoStream(fullPath, size, cryptoProvider, CryptoProvider.Purpose.READ_IN_DIR))
             .on('data', (chunk) => { data = Buffer.concat([data, chunk]); })
             .on('error', e => reject(e))
             .on('end', () => resolve(data));
         });
-        const { encoding } = options;
         if (isExists(encoding)) {
           file = file.toString(encoding);
         }

--- a/packages/parser-core/test/createRangeStream.spec.js
+++ b/packages/parser-core/test/createRangeStream.spec.js
@@ -1,0 +1,74 @@
+import { assert } from 'chai';
+import fs from 'fs';
+
+import createRangeStream from '../src/createRangeStream';
+import Paths from '../../../test/paths';
+
+describe('Util - createRangeStream', () => {
+  const filePath = Paths.DEFAULT;
+  const test = (start, end) => {
+    const readStream = fs.createReadStream(filePath, { highWaterMark: 1024 });
+    return new Promise((resolve, reject) => {
+      let data = Buffer.from([]);
+      readStream
+        .pipe(createRangeStream(start, end))
+        .on('error', error => reject(error))
+        .on('data', chunk => {
+          data = Buffer.concat([data, chunk]);
+        })
+        .on('end', () => resolve(data));
+    });
+  };
+
+  describe('Only certain range of data is taken from stream', () => {
+    const file = fs.readFileSync(filePath);
+
+    it('0~100', () => {
+      return test(0, 100).then(data => {
+        const expected = file.slice(0, 100);
+        assert(data.length === 100);
+        assert(expected.equals(data));
+      });
+    });
+
+    it('100~300', () => {
+      return test(100, 300).then(data => {
+        const expected = file.slice(100, 300);
+        assert(data.length === 200);
+        assert(expected.equals(data));
+      });
+    });
+
+    it('500~2000', () => {
+      return test(500, 2000).then(data => {
+        const expected = file.slice(500, 2000);
+        assert(data.length === 1500);
+        assert(expected.equals(data));
+      });
+    });
+
+    it('500~Infinity', () => {
+      return test(500, Infinity).then(data => {
+        const expected = file.slice(500, file.length);
+        assert(data.length === file.length - 500);
+        assert(expected.equals(data));
+      });
+    });
+
+    it('undefined~undefined', () => {
+      return test().then(data => {
+        const expected = file;
+        assert(expected.length === data.length);
+        assert(expected.equals(data));
+      });
+    });
+
+    it('500~3000000', () => {
+      return test(500, 3000000).then(data => {
+        const expected = file.slice(500, file.length);
+        assert(data.length === file.length - 500);
+        assert(expected.equals(data));
+      });
+    });
+  });
+});

--- a/packages/parser-core/test/readEntries.spec.js
+++ b/packages/parser-core/test/readEntries.spec.js
@@ -45,7 +45,9 @@ describe('Util - entry manager', () => {
 
       const entry = entries.find('mimetype');
       entry.getFile().then(file => file.should.deep.equal(expectedFile.buffer));
-      entry.getFile('utf8').then(file => file.should.equal(expectedFile.string));
+      entry.getFile({ encoding: 'utf8' }).then(file => file.should.equal(expectedFile.string));
+      entry.getFile({ end: 100000 }).then(file => file.should.deep.equal(expectedFile.buffer));
+      entry.getFile({ encoding: 'utf8', end: 11 }).then(file => file.should.deep.equal(expectedFile.string.substr(0, 11)));
     });
   });
 
@@ -73,7 +75,9 @@ describe('Util - entry manager', () => {
 
       const entry = entries.find('mimetype');
       entry.getFile().then(file => file.should.deep.equal(expectedFile.buffer));
-      entry.getFile('utf8').then(file => file.should.equal(expectedFile.string));
+      entry.getFile({ encoding: 'utf8' }).then(file => file.should.equal(expectedFile.string));
+      entry.getFile({ end: 100000 }).then(file => file.should.deep.equal(expectedFile.buffer));
+      entry.getFile({ encoding: 'utf8', end: 11 }).then(file => file.should.deep.equal(expectedFile.string.substr(0, 11)));
     });
   });
 

--- a/packages/parser-core/test/zipUtil.spec.js
+++ b/packages/parser-core/test/zipUtil.spec.js
@@ -17,7 +17,7 @@ describe('Util - Zip', () => {
       entry.should.not.null;
       const buffer = await zip.getFile(entry);
       Buffer.isBuffer(buffer).should.be.true;
-      const string = await zip.getFile(entry, 'utf8');
+      const string = await zip.getFile(entry, { encoding: 'utf8' });
       string.should.equal('application/epub+zip');
     });
   });

--- a/packages/parser-core/yarn.lock
+++ b/packages/parser-core/yarn.lock
@@ -260,7 +260,7 @@ universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
 
-unzipper@^0.9.4:
+unzipper@^0.9.10:
   version "0.9.10"
   resolved "https://registry.yarnpkg.com/unzipper/-/unzipper-0.9.10.tgz#1954ed60f69d102d4416f92825588f2916ba503e"
   dependencies:

--- a/test/paths.js
+++ b/test/paths.js
@@ -32,6 +32,7 @@ const Paths = {
   COMIC: '../../test/res/comic.zip',
   UNZIPPED_COMIC: '../../test/res/comic',
   EXPECTED_COMIC_BOOK: '../../test/res/expectedComicBook.json',
+  EXPECTED_COMIC_BOOK_WITH_SIZE: '../../test/res/expectedComicBookWithSize.json',
   COMIC_FIRST: '../../test/res/comic/1.jpg',
   COMIC_BASE64: '../../test/res/comicBase64.txt',
 };

--- a/test/res/expectedComicBook.json
+++ b/test/res/expectedComicBook.json
@@ -3,182 +3,182 @@
     {
       "index": 0,
       "path": "1.jpg",
-      "fileSize": 504405,
+      "fileSize": 504405
     },
     {
       "index": 1,
       "path": "2.jpg",
-      "fileSize": 465153,
+      "fileSize": 465153
     },
     {
       "index": 2,
       "path": "3.jpg",
-      "fileSize": 699597,
+      "fileSize": 699597
     },
     {
       "index": 3,
       "path": "4.jpg",
-      "fileSize": 660173,
+      "fileSize": 660173
     },
     {
       "index": 4,
       "path": "5.jpg",
-      "fileSize": 686957,
+      "fileSize": 686957
     },
     {
       "index": 5,
       "path": "6.jpg",
-      "fileSize": 746432,
+      "fileSize": 746432
     },
     {
       "index": 6,
       "path": "7.jpg",
-      "fileSize": 751819,
+      "fileSize": 751819
     },
     {
       "index": 7,
       "path": "8.jpg",
-      "fileSize": 736033,
+      "fileSize": 736033
     },
     {
       "index": 8,
       "path": "9.jpg",
-      "fileSize": 724039,
+      "fileSize": 724039
     },
     {
       "index": 9,
       "path": "10.jpg",
-      "fileSize": 660249,
+      "fileSize": 660249
     },
     {
       "index": 10,
       "path": "11.jpg",
-      "fileSize": 675234,
+      "fileSize": 675234
     },
     {
       "index": 11,
       "path": "12.jpg",
-      "fileSize": 613960,
+      "fileSize": 613960
     },
     {
       "index": 12,
       "path": "13.jpg",
-      "fileSize": 709103,
+      "fileSize": 709103
     },
     {
       "index": 13,
       "path": "14.jpg",
-      "fileSize": 711922,
+      "fileSize": 711922
     },
     {
       "index": 14,
       "path": "15.jpg",
-      "fileSize": 701440,
+      "fileSize": 701440
     },
     {
       "index": 15,
       "path": "16.jpg",
-      "fileSize": 717382,
+      "fileSize": 717382
     },
     {
       "index": 16,
       "path": "17.jpg",
-      "fileSize": 684373,
+      "fileSize": 684373
     },
     {
       "index": 17,
       "path": "18.jpg",
-      "fileSize": 703825,
+      "fileSize": 703825
     },
     {
       "index": 18,
       "path": "19.jpg",
-      "fileSize": 659247,
+      "fileSize": 659247
     },
     {
       "index": 19,
       "path": "20.jpg",
-      "fileSize": 709445,
+      "fileSize": 709445
     },
     {
       "index": 20,
       "path": "21.jpg",
-      "fileSize": 675717,
+      "fileSize": 675717
     },
     {
       "index": 21,
       "path": "22.jpg",
-      "fileSize": 718834,
+      "fileSize": 718834
     },
     {
       "index": 22,
       "path": "23.jpg",
-      "fileSize": 771827,
+      "fileSize": 771827
     },
     {
       "index": 23,
       "path": "24.jpg",
-      "fileSize": 519713,
+      "fileSize": 519713
     },
     {
       "index": 24,
       "path": "25.jpg",
-      "fileSize": 444754,
+      "fileSize": 444754
     },
     {
       "index": 25,
       "path": "26.jpg",
-      "fileSize": 623711,
+      "fileSize": 623711
     },
     {
       "index": 26,
       "path": "27.jpg",
-      "fileSize": 738282,
+      "fileSize": 738282
     },
     {
       "index": 27,
       "path": "28.jpg",
-      "fileSize": 715704,
+      "fileSize": 715704
     },
     {
       "index": 28,
       "path": "29.jpg",
-      "fileSize": 690262,
+      "fileSize": 690262
     },
     {
       "index": 29,
       "path": "30.jpg",
-      "fileSize": 700029,
+      "fileSize": 700029
     },
     {
       "index": 30,
       "path": "31.jpg",
-      "fileSize": 695095,
+      "fileSize": 695095
     },
     {
       "index": 31,
       "path": "32.jpg",
-      "fileSize": 708847,
+      "fileSize": 708847
     },
     {
       "index": 32,
       "path": "33.jpg",
-      "fileSize": 650240,
+      "fileSize": 650240
     },
     {
       "index": 33,
       "path": "34.jpg",
-      "fileSize": 691452,
+      "fileSize": 691452
     },
     {
       "index": 34,
       "path": "35.jpg",
-      "fileSize": 487918,
+      "fileSize": 487918
     },
     {
       "index": 35,
       "path": "36.jpg",
-      "fileSize": 523093,
+      "fileSize": 523093
     }
   ]
 }

--- a/test/res/expectedComicBook.json
+++ b/test/res/expectedComicBook.json
@@ -3,182 +3,182 @@
     {
       "index": 0,
       "path": "1.jpg",
-      "size": 504405
+      "fileSize": 504405,
     },
     {
       "index": 1,
       "path": "2.jpg",
-      "size": 465153
+      "fileSize": 465153,
     },
     {
       "index": 2,
       "path": "3.jpg",
-      "size": 699597
+      "fileSize": 699597,
     },
     {
       "index": 3,
       "path": "4.jpg",
-      "size": 660173
+      "fileSize": 660173,
     },
     {
       "index": 4,
       "path": "5.jpg",
-      "size": 686957
+      "fileSize": 686957,
     },
     {
       "index": 5,
       "path": "6.jpg",
-      "size": 746432
+      "fileSize": 746432,
     },
     {
       "index": 6,
       "path": "7.jpg",
-      "size": 751819
+      "fileSize": 751819,
     },
     {
       "index": 7,
       "path": "8.jpg",
-      "size": 736033
+      "fileSize": 736033,
     },
     {
       "index": 8,
       "path": "9.jpg",
-      "size": 724039
+      "fileSize": 724039,
     },
     {
       "index": 9,
       "path": "10.jpg",
-      "size": 660249
+      "fileSize": 660249,
     },
     {
       "index": 10,
       "path": "11.jpg",
-      "size": 675234
+      "fileSize": 675234,
     },
     {
       "index": 11,
       "path": "12.jpg",
-      "size": 613960
+      "fileSize": 613960,
     },
     {
       "index": 12,
       "path": "13.jpg",
-      "size": 709103
+      "fileSize": 709103,
     },
     {
       "index": 13,
       "path": "14.jpg",
-      "size": 711922
+      "fileSize": 711922,
     },
     {
       "index": 14,
       "path": "15.jpg",
-      "size": 701440
+      "fileSize": 701440,
     },
     {
       "index": 15,
       "path": "16.jpg",
-      "size": 717382
+      "fileSize": 717382,
     },
     {
       "index": 16,
       "path": "17.jpg",
-      "size": 684373
+      "fileSize": 684373,
     },
     {
       "index": 17,
       "path": "18.jpg",
-      "size": 703825
+      "fileSize": 703825,
     },
     {
       "index": 18,
       "path": "19.jpg",
-      "size": 659247
+      "fileSize": 659247,
     },
     {
       "index": 19,
       "path": "20.jpg",
-      "size": 709445
+      "fileSize": 709445,
     },
     {
       "index": 20,
       "path": "21.jpg",
-      "size": 675717
+      "fileSize": 675717,
     },
     {
       "index": 21,
       "path": "22.jpg",
-      "size": 718834
+      "fileSize": 718834,
     },
     {
       "index": 22,
       "path": "23.jpg",
-      "size": 771827
+      "fileSize": 771827,
     },
     {
       "index": 23,
       "path": "24.jpg",
-      "size": 519713
+      "fileSize": 519713,
     },
     {
       "index": 24,
       "path": "25.jpg",
-      "size": 444754
+      "fileSize": 444754,
     },
     {
       "index": 25,
       "path": "26.jpg",
-      "size": 623711
+      "fileSize": 623711,
     },
     {
       "index": 26,
       "path": "27.jpg",
-      "size": 738282
+      "fileSize": 738282,
     },
     {
       "index": 27,
       "path": "28.jpg",
-      "size": 715704
+      "fileSize": 715704,
     },
     {
       "index": 28,
       "path": "29.jpg",
-      "size": 690262
+      "fileSize": 690262,
     },
     {
       "index": 29,
       "path": "30.jpg",
-      "size": 700029
+      "fileSize": 700029,
     },
     {
       "index": 30,
       "path": "31.jpg",
-      "size": 695095
+      "fileSize": 695095,
     },
     {
       "index": 31,
       "path": "32.jpg",
-      "size": 708847
+      "fileSize": 708847,
     },
     {
       "index": 32,
       "path": "33.jpg",
-      "size": 650240
+      "fileSize": 650240,
     },
     {
       "index": 33,
       "path": "34.jpg",
-      "size": 691452
+      "fileSize": 691452,
     },
     {
       "index": 34,
       "path": "35.jpg",
-      "size": 487918
+      "fileSize": 487918,
     },
     {
       "index": 35,
       "path": "36.jpg",
-      "size": 523093
+      "fileSize": 523093,
     }
   ]
 }

--- a/test/res/expectedComicBookWithSize.json
+++ b/test/res/expectedComicBookWithSize.json
@@ -1,0 +1,256 @@
+{
+  "items": [
+    {
+      "index": 0,
+      "path": "1.jpg",
+      "fileSize": 504405,
+      "width": 1000,
+      "height": 1481
+    },
+    {
+      "index": 1,
+      "path": "2.jpg",
+      "fileSize": 465153,
+      "width": 1000,
+      "height": 1437
+    },
+    {
+      "index": 2,
+      "path": "3.jpg",
+      "fileSize": 699597,
+      "width": 1000,
+      "height": 1495
+    },
+    {
+      "index": 3,
+      "path": "4.jpg",
+      "fileSize": 660173,
+      "width": 1000,
+      "height": 1421
+    },
+    {
+      "index": 4,
+      "path": "5.jpg",
+      "fileSize": 686957,
+      "width": 1000,
+      "height": 1454
+    },
+    {
+      "index": 5,
+      "path": "6.jpg",
+      "fileSize": 746432,
+      "width": 1000,
+      "height": 1421
+    },
+    {
+      "index": 6,
+      "path": "7.jpg",
+      "fileSize": 751819,
+      "width": 1000,
+      "height": 1434
+    },
+    {
+      "index": 7,
+      "path": "8.jpg",
+      "fileSize": 736033,
+      "width": 1000,
+      "height": 1431
+    },
+    {
+      "index": 8,
+      "path": "9.jpg",
+      "fileSize": 724039,
+      "width": 1000,
+      "height": 1443
+    },
+    {
+      "index": 9,
+      "path": "10.jpg",
+      "fileSize": 660249,
+      "width": 1000,
+      "height": 1401
+    },
+    {
+      "index": 10,
+      "path": "11.jpg",
+      "fileSize": 675234,
+      "width": 1000,
+      "height": 1436
+    },
+    {
+      "index": 11,
+      "path": "12.jpg",
+      "fileSize": 613960,
+      "width": 1000,
+      "height": 1415
+    },
+    {
+      "index": 12,
+      "path": "13.jpg",
+      "fileSize": 709103,
+      "width": 1000,
+      "height": 1446
+    },
+    {
+      "index": 13,
+      "path": "14.jpg",
+      "fileSize": 711922,
+      "width": 1000,
+      "height": 1459
+    },
+    {
+      "index": 14,
+      "path": "15.jpg",
+      "fileSize": 701440,
+      "width": 1000,
+      "height": 1443
+    },
+    {
+      "index": 15,
+      "path": "16.jpg",
+      "fileSize": 717382,
+      "width": 1000,
+      "height": 1429
+    },
+    {
+      "index": 16,
+      "path": "17.jpg",
+      "fileSize": 684373,
+      "width": 1000,
+      "height": 1438
+    },
+    {
+      "index": 17,
+      "path": "18.jpg",
+      "fileSize": 703825,
+      "width": 1000,
+      "height": 1407
+    },
+    {
+      "index": 18,
+      "path": "19.jpg",
+      "fileSize": 659247,
+      "width": 1000,
+      "height": 1429
+    },
+    {
+      "index": 19,
+      "path": "20.jpg",
+      "fileSize": 709445,
+      "width": 1000,
+      "height": 1430
+    },
+    {
+      "index": 20,
+      "path": "21.jpg",
+      "fileSize": 675717,
+      "width": 1000,
+      "height": 1395
+    },
+    {
+      "index": 21,
+      "path": "22.jpg",
+      "fileSize": 718834,
+      "width": 1000,
+      "height": 1442
+    },
+    {
+      "index": 22,
+      "path": "23.jpg",
+      "fileSize": 771827,
+      "width": 1000,
+      "height": 1430
+    },
+    {
+      "index": 23,
+      "path": "24.jpg",
+      "fileSize": 519713,
+      "width": 1000,
+      "height": 1423
+    },
+    {
+      "index": 24,
+      "path": "25.jpg",
+      "fileSize": 444754,
+      "width": 1000,
+      "height": 1447
+    },
+    {
+      "index": 25,
+      "path": "26.jpg",
+      "fileSize": 623711,
+      "width": 1000,
+      "height": 1413
+    },
+    {
+      "index": 26,
+      "path": "27.jpg",
+      "fileSize": 738282,
+      "width": 1000,
+      "height": 1406
+    },
+    {
+      "index": 27,
+      "path": "28.jpg",
+      "fileSize": 715704,
+      "width": 1000,
+      "height": 1435
+    },
+    {
+      "index": 28,
+      "path": "29.jpg",
+      "fileSize": 690262,
+      "width": 1000,
+      "height": 1432
+    },
+    {
+      "index": 29,
+      "path": "30.jpg",
+      "fileSize": 700029,
+      "width": 1000,
+      "height": 1429
+    },
+    {
+      "index": 30,
+      "path": "31.jpg",
+      "fileSize": 695095,
+      "width": 1000,
+      "height": 1428
+    },
+    {
+      "index": 31,
+      "path": "32.jpg",
+      "fileSize": 708847,
+      "width": 1000,
+      "height": 1413
+    },
+    {
+      "index": 32,
+      "path": "33.jpg",
+      "fileSize": 650240,
+      "width": 1000,
+      "height": 1420
+    },
+    {
+      "index": 33,
+      "path": "34.jpg",
+      "fileSize": 691452,
+      "width": 1000,
+      "height": 1430
+    },
+    {
+      "index": 34,
+      "path": "35.jpg",
+      "fileSize": 487918,
+      "width": 1000,
+      "height": 1377
+    },
+    {
+      "index": 35,
+      "path": "36.jpg",
+      "fileSize": 523093,
+      "width": 1000,
+      "height": 1366
+    }
+  ]
+}


### PR DESCRIPTION
## 작업 내역

- 이미지 크기를 파싱하는 옵션(`parseImageSize`) 추가
  - 성능 저하를 야기하기 때문에 파싱하지 않음을 기본 설정으로
  - 부울값 이외 정수값 설정을 통해 성능 저하를 최소화시킬 수 있음
- `ComicBook.Item` 프로퍼티 추가 및 네이밍 수정
- 특정 범위의 버퍼만 푸시하는 `createRangeStream` 유틸 추가
- 파일의 앞쪽 일부분을 읽을 수 있는 옵션 추가를 위해 `entry.getFile`의 파라미터 형태를 수정
  - 기존: `getFile(encoding)`
  - 수정: `getFile({ encoding, end })`
