### PR TITLE
Fix cache file encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-* None.
+### Fixed
+
+* Fix an issue where broken cache values if that save out of ascii range.
 
 ## [0.5.0 (2019-02-13)]
 

--- a/packages/parser-core/src/cacheFile.js
+++ b/packages/parser-core/src/cacheFile.js
@@ -45,5 +45,5 @@ export function writeCacheFile(key, message, overwrite = false) {
   if (!fs.existsSync(cachePath)) {
     fs.mkdirpSync(cachePath);
   }
-  fs.writeFileSync(filePath, message, { flag: overwrite ? 'w' : 'a', encoding: 'binary' });
+  fs.writeFileSync(filePath, message, { flag: overwrite ? 'w' : 'a', encoding: 'utf8' });
 }

--- a/packages/parser-core/test/cacheFile.spec.js
+++ b/packages/parser-core/test/cacheFile.spec.js
@@ -15,7 +15,7 @@ should(); // Initialize should
 
 describe('Util - read/write cache file', () => {
   const key = 'key';
-  const value = 'value';
+  const value = '껄껄';
 
   it('Access to non-existent key', () => {
     assert(readCacheFile(key) === null);


### PR DESCRIPTION
## 작업 내역

- 아스키 범위를 벗어나는 문자열을 캐시 파일에 저장할 경우 읽을 때 인코딩이 깨지는 문제 수정