### PR TITLE
Fix read entries bug

### DIFF
--- a/packages/parser-core/src/Parser.js
+++ b/packages/parser-core/src/Parser.js
@@ -1,5 +1,6 @@
 import fs from 'fs';
 
+import { removeAllCacheFiles } from './cacheFile';
 import CryptoProvider from './CryptoProvider';
 import Errors, { createError, mustOverride } from './errors';
 import Logger from './Logger';
@@ -124,6 +125,7 @@ class Parser {
     if (isExists(cryptoProvider) && !(cryptoProvider instanceof CryptoProvider)) {
       throw createError(Errors.EINVAL, 'cryptoProvider', 'reason', 'must be CryptoProvider subclassing type');
     }
+    removeAllCacheFiles();
     const { namespace, logLevel } = loggerOptions;
     const logger = new Logger(namespace || Parser.name);
     logger.logLevel = logLevel;
@@ -234,7 +236,7 @@ class Parser {
     const ParseContext = this._getParseContextClass();
     const context = new ParseContext();
     context.options = mergeObjects(parseDefaultOptions, options);
-    context.entries = await readEntries(this.input, this.cryptoProvider, this.logger, true);
+    context.entries = await readEntries(this.input, this.cryptoProvider, this.logger);
     this.logger.debug(`Ready to parse with options: ${JSON.stringify(context.options)}.`);
     return context;
   }

--- a/packages/parser-core/src/Parser.js
+++ b/packages/parser-core/src/Parser.js
@@ -1,6 +1,6 @@
 import fs from 'fs';
 
-import { removeAllCacheFiles } from './cacheFile';
+import { removeCacheFile } from './cacheFile';
 import CryptoProvider from './CryptoProvider';
 import Errors, { createError, mustOverride } from './errors';
 import Logger from './Logger';
@@ -119,13 +119,13 @@ class Parser {
       if (!fs.existsSync(input)) {
         throw createError(Errors.ENOENT, input);
       }
+      removeCacheFile(input);
     } else {
       throw createError(Errors.EINVAL, 'input', 'reason', 'must be String type');
     }
     if (isExists(cryptoProvider) && !(cryptoProvider instanceof CryptoProvider)) {
       throw createError(Errors.EINVAL, 'cryptoProvider', 'reason', 'must be CryptoProvider subclassing type');
     }
-    removeAllCacheFiles();
     const { namespace, logLevel } = loggerOptions;
     const logger = new Logger(namespace || Parser.name);
     logger.logLevel = logLevel;

--- a/packages/parser-core/src/readEntries.js
+++ b/packages/parser-core/src/readEntries.js
@@ -1,7 +1,7 @@
 import fs from 'fs-extra';
 import path from 'path';
 
-import { removeAllCacheFiles, readCacheFile, writeCacheFile } from './cacheFile';
+import { removeCacheFile, readCacheFile, writeCacheFile } from './cacheFile';
 import createCryptoStream from './createCryptoStream';
 import createRangeStream from './createRangeStream';
 import CryptoProvider from './CryptoProvider';
@@ -65,7 +65,7 @@ function fromDirectory(dir, cryptoProvider) {
               .on('error', e => reject(e))
               .on('end', () => resolve(data));
           } else {
-            removeAllCacheFiles();
+            removeCacheFile(dir);
             throw createError(Errors.ENOFILE, fullPath);
           }
         });

--- a/packages/parser-core/src/readEntries.js
+++ b/packages/parser-core/src/readEntries.js
@@ -33,20 +33,16 @@ function fromZip(zip) {
   }, []));
 }
 
-function fromDirectory(dir, cryptoProvider, resetCache) {
-  let pathes = (() => {
+function fromDirectory(dir, cryptoProvider) {
+  let paths = (() => {
     /* istanbul ignore next */
     try { return JSON.parse(readCacheFile(dir) || '[]'); } catch (e) { return []; }
   })();
-  if (resetCache || pathes.length === 0) {
-    pathes = getPathes(dir);
-    /* istanbul ignore else */
-    if (resetCache) {
-      removeAllCacheFiles();
-    }
-    writeCacheFile(dir, JSON.stringify(pathes));
+  if (paths.length === 0) {
+    paths = getPathes(dir);
+    writeCacheFile(dir, JSON.stringify(paths), true);
   }
-  return create(dir, pathes.reduce((entries, fullPath) => {
+  return create(dir, paths.reduce((entries, fullPath) => {
     const subPathOffset = path.normalize(dir).length + path.sep.length;
     const size = (() => {
       /* istanbul ignore next */
@@ -76,7 +72,7 @@ function fromDirectory(dir, cryptoProvider, resetCache) {
   }, []));
 }
 
-export default async function readEntries(input, cryptoProvider, logger, resetCache = false) {
+export default async function readEntries(input, cryptoProvider, logger) {
   if (fs.lstatSync(input).isFile()) { // TODO: When input is Buffer.
     /* istanbul ignore if */
     if (isExists(cryptoProvider)) {
@@ -86,5 +82,5 @@ export default async function readEntries(input, cryptoProvider, logger, resetCa
     const zip = await openZip(input, cryptoProvider, logger);
     return fromZip(zip);
   }
-  return fromDirectory(input, cryptoProvider, resetCache);
+  return fromDirectory(input, cryptoProvider);
 }

--- a/packages/parser-core/src/zipUtil.js
+++ b/packages/parser-core/src/zipUtil.js
@@ -15,12 +15,12 @@ function find(entryPath) {
 async function getFile(entry, options = {}) {
   const { encoding, end } = options;
   let file = await new Promise((resolve, reject) => {
-    const size = entry.uncompressedSize;
+    const totalSize = Math.min(end || Infinity, entry.uncompressedSize);
     let data = Buffer.from([]);
     const stream = entry.stream();
     stream // is DuplexStream.
       .pipe(createRangeStream(0, end))
-      .pipe(createCryptoStream(entry.path, size, this.cryptoProvider, CryptoProvider.Purpose.READ_IN_ZIP))
+      .pipe(createCryptoStream(entry.path, totalSize, this.cryptoProvider, CryptoProvider.Purpose.READ_IN_ZIP))
       .on('data', (chunk) => { data = Buffer.concat([data, chunk]); })
       .on('error', e => reject(e))
       .on('end', () => resolve(data));

--- a/packages/parser-core/test/readEntries.spec.js
+++ b/packages/parser-core/test/readEntries.spec.js
@@ -2,6 +2,8 @@ import { should } from 'chai';
 import fs from 'fs';
 import path from 'path';
 
+import { readCacheFile, writeCacheFile } from '../src/cacheFile';
+import Errors from '../src/errors';
 import { isString } from '../src/typecheck';
 import readEntries from '../src/readEntries';
 import stringContains from '../src/stringContains';
@@ -16,76 +18,112 @@ describe('Util - entry manager', () => {
     string: fs.readFileSync(filePath, 'utf8'),
   };
 
-  it('Read entries from zip', () => {
-    return readEntries(Paths.DEFAULT).then(entries => {
-      const expectedList = [
-        'mimetype',
-        'META-INF/container.xml',
-        'OEBPS/content.opf',
-        'OEBPS/Fonts/NotoSans-Regular.ttf',
-        'OEBPS/Images/ridibooks.png',
-        'OEBPS/Images/ridibooks_logo.png',
-        'OEBPS/Styles/Style0001.css',
-        'OEBPS/Text/Cover.xhtml',
-        'OEBPS/Text/Section0001.xhtml',
-        'OEBPS/Text/Section0002.xhtml',
-        'OEBPS/Text/Section0004.xhtml',
-        'OEBPS/Text/Section0005.xhtml',
-        'OEBPS/Text/Section0006.xhtml',
-        'OEBPS/toc.ncx',
-        'OEBPS/Video/empty.mp4',
-      ];
+  const expectedListForZip = [
+    'mimetype',
+    'META-INF/container.xml',
+    'OEBPS/content.opf',
+    'OEBPS/Fonts/NotoSans-Regular.ttf',
+    'OEBPS/Images/ridibooks.png',
+    'OEBPS/Images/ridibooks_logo.png',
+    'OEBPS/Styles/Style0001.css',
+    'OEBPS/Text/Cover.xhtml',
+    'OEBPS/Text/Section0001.xhtml',
+    'OEBPS/Text/Section0002.xhtml',
+    'OEBPS/Text/Section0004.xhtml',
+    'OEBPS/Text/Section0005.xhtml',
+    'OEBPS/Text/Section0006.xhtml',
+    'OEBPS/toc.ncx',
+    'OEBPS/Video/empty.mp4',
+  ];
+
+  it('Read entries from zip', done => {
+    (async () => {
+      const entries = await readEntries(Paths.DEFAULT);
       isString(entries.source).should.be.false;
-      entries.map(entry => entry.entryPath).should.deep.equal(expectedList);
+      entries.map(entry => entry.entryPath).should.deep.equal(expectedListForZip);
       entries.forEach(entry => {
         const keys = Object.keys(entry);
         stringContains(keys, 'method').should.be.true;
         stringContains(keys, 'extraFieldLength').should.be.true;
       });
-
+  
       const entry = entries.find('mimetype');
-      entry.getFile().then(file => file.should.deep.equal(expectedFile.buffer));
-      entry.getFile({ encoding: 'utf8' }).then(file => file.should.equal(expectedFile.string));
-      entry.getFile({ end: 100000 }).then(file => file.should.deep.equal(expectedFile.buffer));
-      entry.getFile({ encoding: 'utf8', end: 11 }).then(file => file.should.deep.equal(expectedFile.string.substr(0, 11)));
-    });
+      let file = await entry.getFile();
+      file.should.deep.equal(expectedFile.buffer);
+      file = await entry.getFile({ encoding: 'utf8' });
+      file.should.equal(expectedFile.string);
+      file = await entry.getFile({ end: 100000 });
+      file.should.deep.equal(expectedFile.buffer);
+      file = await entry.getFile({ encoding: 'utf8', end: 11 });
+      file.should.deep.equal(expectedFile.string.substr(0, 11));
+
+      done();
+    })();
+  });
+  
+  const expectedListForDir = [
+    'META-INF/container.xml',
+    'OEBPS/Fonts/NotoSans-Regular.ttf',
+    'OEBPS/Images/ridibooks.png',
+    'OEBPS/Images/ridibooks_logo.png',
+    'OEBPS/Styles/Style0001.css',
+    'OEBPS/Text/Cover.xhtml',
+    'OEBPS/Text/Section0001.xhtml',
+    'OEBPS/Text/Section0002.xhtml',
+    'OEBPS/Text/Section0004.xhtml',
+    'OEBPS/Text/Section0005.xhtml',
+    'OEBPS/Text/Section0006.xhtml',
+    'OEBPS/Video/empty.mp4',
+    'OEBPS/content.opf',
+    'OEBPS/toc.ncx',
+    'mimetype',
+  ];
+
+  it('Read entries from directory', done => {
+    (async () => {
+      const entries = await readEntries(Paths.UNZIPPED_DEFAULT);
+      isString(entries.source).should.be.true;
+      entries.map(entry => entry.entryPath).should.deep.equal(expectedListForDir);
+  
+      const entry = entries.find('mimetype');
+      let file = await entry.getFile();
+      file.should.deep.equal(expectedFile.buffer);
+      file = await entry.getFile({ encoding: 'utf8' });
+      file.should.equal(expectedFile.string);
+      file = await entry.getFile({ end: 100000 });
+      file.should.deep.equal(expectedFile.buffer);
+      file = await entry.getFile({ encoding: 'utf8', end: 11 });
+      file.should.deep.equal(expectedFile.string.substr(0, 11));
+
+      done();
+    })();
   });
 
-  it('Read entries from directory', () => {
+  it('Read entries from directory (cached)', () => {
     return readEntries(Paths.UNZIPPED_DEFAULT).then(entries => {
-      const expectedList = [
-        'META-INF/container.xml',
-        'OEBPS/Fonts/NotoSans-Regular.ttf',
-        'OEBPS/Images/ridibooks.png',
-        'OEBPS/Images/ridibooks_logo.png',
-        'OEBPS/Styles/Style0001.css',
-        'OEBPS/Text/Cover.xhtml',
-        'OEBPS/Text/Section0001.xhtml',
-        'OEBPS/Text/Section0002.xhtml',
-        'OEBPS/Text/Section0004.xhtml',
-        'OEBPS/Text/Section0005.xhtml',
-        'OEBPS/Text/Section0006.xhtml',
-        'OEBPS/Video/empty.mp4',
-        'OEBPS/content.opf',
-        'OEBPS/toc.ncx',
-        'mimetype',
-      ];
       isString(entries.source).should.be.true;
-      entries.map(entry => entry.entryPath).should.deep.equal(expectedList);
-
-      const entry = entries.find('mimetype');
-      entry.getFile().then(file => file.should.deep.equal(expectedFile.buffer));
-      entry.getFile({ encoding: 'utf8' }).then(file => file.should.equal(expectedFile.string));
-      entry.getFile({ end: 100000 }).then(file => file.should.deep.equal(expectedFile.buffer));
-      entry.getFile({ encoding: 'utf8', end: 11 }).then(file => file.should.deep.equal(expectedFile.string.substr(0, 11)));
+      entries.map(entry => entry.entryPath).should.deep.equal(expectedListForDir);
     });
   });
 
   describe('Error Situation', () => {
     it('Invalid file path', () => {
       return readEntries('?!').catch((err) => {
-        err.code.should.equal('ENOENT');
+        err.code.should.equal(Errors.ENOENT.code); 
       });
+    });
+
+    it('No such file from directory', done => {
+      (async () => {
+        const dir = Paths.UNZIPPED_DEFAULT;
+        const paths = JSON.parse(readCacheFile(dir));
+        paths[paths.length - 1] = `${paths[paths.length - 1]}.bak`;
+        writeCacheFile(dir, JSON.stringify(paths), true);
+        const entries = await readEntries(dir);
+        const entry = entries.find('mimetype.bak');
+        try { await entry.getFile() } catch (err) { err.code.should.equal(Errors.ENOFILE.code); }
+        done();
+      })();
     });
   });
 });


### PR DESCRIPTION
## 작업 내역

- 캐시 파일을 덮어쓰지 않고 이어쓰고 있는 문제 수정
- 엣지 케이스에 대한 테스트 케이스 추가
  - 암호화와 `getFile`의 `end` 옵션을 같이 사용할 때 발생하는 오작동
  - `ReadStream` 생성할 때 발생하는 오작동